### PR TITLE
Add daily tasks tab and notification

### DIFF
--- a/BigFrogsApp/App.js
+++ b/BigFrogsApp/App.js
@@ -1,17 +1,19 @@
 import React, { useState, useEffect } from 'react';
 import { SafeAreaView, View, Text, TextInput, TouchableOpacity, FlatList, StyleSheet } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import * as Notifications from 'expo-notifications';
 
 const STORAGE_KEY = '@big_frogs_tasks';
+const DAILY_KEY = '@daily_tasks';
 
-export default function App() {
+function BigFrogsScreen() {
   const [tasks, setTasks] = useState([]);
   const [taskText, setTaskText] = useState('');
   const [taskPriority, setTaskPriority] = useState('1');
 
-  useEffect(() => {
-    loadTasks();
-  }, []);
+  useEffect(() => { loadTasks(); }, []);
 
   async function loadTasks() {
     try {
@@ -20,10 +22,7 @@ export default function App() {
       const today = new Date().toISOString().split('T')[0];
       let currentTasks = stored.tasks || [];
       if (stored.lastDate !== today) {
-        // carry over incomplete tasks to today with priority 1
-        currentTasks = currentTasks
-          .filter(t => !t.completed)
-          .map(t => ({ ...t, priority: 1 }));
+        currentTasks = currentTasks.filter(t => !t.completed).map(t => ({ ...t, priority: 1 }));
         stored = { lastDate: today, tasks: currentTasks };
         await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
       }
@@ -45,12 +44,7 @@ export default function App() {
 
   function addTask() {
     if (!taskText) return;
-    const newTask = {
-      id: Date.now().toString(),
-      text: taskText,
-      priority: parseInt(taskPriority) || 1,
-      completed: false,
-    };
+    const newTask = { id: Date.now().toString(), text: taskText, priority: parseInt(taskPriority) || 1, completed: false };
     const updated = [...tasks, newTask];
     saveTasks(updated);
     setTaskText('');
@@ -71,77 +65,124 @@ export default function App() {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.inputRow}>
-        <TextInput
-          style={styles.input}
-          placeholder="Add Big Frog"
-          value={taskText}
-          onChangeText={setTaskText}
-        />
-        <TextInput
-          style={styles.priorityInput}
-          placeholder="Priority"
-          value={taskPriority}
-          keyboardType="numeric"
-          onChangeText={setTaskPriority}
-        />
+        <TextInput style={styles.input} placeholder="Add Big Frog" value={taskText} onChangeText={setTaskText} />
+        <TextInput style={styles.priorityInput} placeholder="Priority" value={taskPriority} keyboardType="numeric" onChangeText={setTaskPriority} />
         <TouchableOpacity onPress={addTask} style={styles.addButton}>
           <Text style={styles.addButtonText}>Add</Text>
         </TouchableOpacity>
       </View>
-      <FlatList
-        data={tasks}
-        keyExtractor={item => item.id}
-        renderItem={renderItem}
-      />
+      <FlatList data={tasks} keyExtractor={item => item.id} renderItem={renderItem} />
     </SafeAreaView>
   );
 }
 
+function DailyTasksScreen() {
+  const [tasks, setTasks] = useState([]);
+  const [taskText, setTaskText] = useState('');
+
+  useEffect(() => { loadTasks(); requestPermissions(); }, []);
+  useEffect(() => { updateNotification(); }, [tasks]);
+
+  async function requestPermissions() {
+    await Notifications.requestPermissionsAsync();
+  }
+
+  async function loadTasks() {
+    try {
+      const jsonValue = await AsyncStorage.getItem(DAILY_KEY);
+      let stored = jsonValue != null ? JSON.parse(jsonValue) : { lastDate: null, tasks: [] };
+      const today = new Date().toISOString().split('T')[0];
+      if (stored.lastDate !== today) {
+        stored.tasks = stored.tasks.map(t => ({ ...t, completed: false }));
+        stored.lastDate = today;
+        await AsyncStorage.setItem(DAILY_KEY, JSON.stringify(stored));
+      }
+      setTasks(stored.tasks);
+    } catch (e) {
+      console.error('Failed to load daily tasks', e);
+    }
+  }
+
+  async function saveTasks(updatedTasks) {
+    try {
+      const today = new Date().toISOString().split('T')[0];
+      await AsyncStorage.setItem(DAILY_KEY, JSON.stringify({ lastDate: today, tasks: updatedTasks }));
+      setTasks(updatedTasks);
+    } catch (e) {
+      console.error('Failed to save daily tasks', e);
+    }
+  }
+
+  function addTask() {
+    if (!taskText) return;
+    const newTask = { id: Date.now().toString(), text: taskText, completed: false };
+    const updated = [...tasks, newTask];
+    saveTasks(updated);
+    setTaskText('');
+  }
+
+  function toggleTask(id) {
+    const updated = tasks.map(t => (t.id === id ? { ...t, completed: !t.completed } : t));
+    saveTasks(updated);
+  }
+
+  async function updateNotification() {
+    await Notifications.cancelAllScheduledNotificationsAsync();
+    const incomplete = tasks.some(t => !t.completed);
+    if (incomplete) {
+      const now = new Date();
+      const trigger = new Date();
+      trigger.setHours(21, 0, 0, 0); // 9 PM reminder
+      if (trigger <= now) {
+        trigger.setDate(trigger.getDate() + 1);
+      }
+      await Notifications.scheduleNotificationAsync({
+        content: { title: 'Daily Tasks Reminder', body: 'You have pending daily tasks!' },
+        trigger,
+      });
+    }
+  }
+
+  const renderItem = ({ item }) => (
+    <TouchableOpacity onPress={() => toggleTask(item.id)} style={styles.item}>
+      <Text style={item.completed ? styles.completed : styles.text}>{item.text}</Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.inputRow}>
+        <TextInput style={styles.input} placeholder="Add Daily Task" value={taskText} onChangeText={setTaskText} />
+        <TouchableOpacity onPress={addTask} style={styles.addButton}>
+          <Text style={styles.addButtonText}>Add</Text>
+        </TouchableOpacity>
+      </View>
+      <FlatList data={tasks} keyExtractor={item => item.id} renderItem={renderItem} />
+    </SafeAreaView>
+  );
+}
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Big Frogs" component={BigFrogsScreen} />
+        <Tab.Screen name="Daily Tasks" component={DailyTasksScreen} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: 16,
-  },
-  inputRow: {
-    flexDirection: 'row',
-    marginBottom: 16,
-  },
-  input: {
-    flex: 1,
-    borderWidth: 1,
-    borderColor: '#ccc',
-    padding: 8,
-    borderRadius: 4,
-  },
-  priorityInput: {
-    width: 60,
-    marginLeft: 8,
-    borderWidth: 1,
-    borderColor: '#ccc',
-    padding: 8,
-    borderRadius: 4,
-  },
-  addButton: {
-    backgroundColor: '#007AFF',
-    paddingHorizontal: 12,
-    justifyContent: 'center',
-    marginLeft: 8,
-    borderRadius: 4,
-  },
-  addButtonText: {
-    color: '#fff',
-  },
-  item: {
-    padding: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: '#eee',
-  },
-  text: {
-    fontSize: 16,
-  },
-  completed: {
-    fontSize: 16,
-    textDecorationLine: 'line-through',
-    color: '#999',
-  },
+  container: { flex: 1, padding: 16 },
+  inputRow: { flexDirection: 'row', marginBottom: 16 },
+  input: { flex: 1, borderWidth: 1, borderColor: '#ccc', padding: 8, borderRadius: 4 },
+  priorityInput: { width: 60, marginLeft: 8, borderWidth: 1, borderColor: '#ccc', padding: 8, borderRadius: 4 },
+  addButton: { backgroundColor: '#007AFF', paddingHorizontal: 12, justifyContent: 'center', marginLeft: 8, borderRadius: 4 },
+  addButtonText: { color: '#fff' },
+  item: { padding: 12, borderBottomWidth: 1, borderBottomColor: '#eee' },
+  text: { fontSize: 16 },
+  completed: { fontSize: 16, textDecorationLine: 'line-through', color: '#999' },
 });

--- a/BigFrogsApp/package.json
+++ b/BigFrogsApp/package.json
@@ -12,6 +12,11 @@
     "expo": "~48.0.18",
     "react": "18.2.0",
     "react-native": "0.71.8",
-    "@react-native-async-storage/async-storage": "^1.17.11"
+    "@react-native-async-storage/async-storage": "^1.17.11",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.11",
+    "react-native-safe-area-context": "4.5.0",
+    "react-native-screens": "~3.20.0",
+    "expo-notifications": "~0.18.1"
   }
 }


### PR DESCRIPTION
## Summary
- add `@react-navigation` and `expo-notifications` dependencies
- restructure `App.js` to provide bottom tab navigation
- create `DailyTasksScreen` with daily reset and notification reminder

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e902fc6208328ad188629ffddbce9